### PR TITLE
Fix missing doc_name in ingestion update status request

### DIFF
--- a/src/ingestion_service/document_ingestor.py
+++ b/src/ingestion_service/document_ingestor.py
@@ -1,4 +1,6 @@
 import hashlib
+import os
+from urllib.parse import urlparse
 from typing import List
 from src.ingestion_service.bootstrap import ProgressCallback, process_document
 from src.ingestion_service.document_management_client import DocumentManagementClient
@@ -7,6 +9,7 @@ from src.ingestion_service.vector_store_builder import VectorStoreBuilder
 import logging
 from src.shared.constants import DocumentStatus
 from src.shared.exceptions import (
+    DocumentHashConflictException,
     IngestionRequestException,
     NoDocumentsException,
 )
@@ -47,6 +50,7 @@ class DocumentIngestor:
         document: str,
     ) -> None:
         doc_hash = hashlib.md5(document.encode()).hexdigest()
+        doc_name = self._extract_doc_name(document)
         try:
             doc_status = self.dms_client.get_document_status(doc_hash)
         except Exception:
@@ -54,7 +58,9 @@ class DocumentIngestor:
             raise
         if doc_status != DocumentStatus.COMPLETED:
             try:
-                self.dms_client.update_document_status(doc_hash, DocumentStatus.PENDING)
+                self.dms_client.update_document_status(
+                    doc_hash, doc_name, DocumentStatus.PENDING
+                )
                 docs = process_document(
                     document, self.file_loader, self.vector_store_builder, self.progress
                 )
@@ -66,16 +72,26 @@ class DocumentIngestor:
                     self.vector_store_builder.add_documents_to_vector_store(docs)
                     self.progress(f"✅ Docs from {document} saved.")
                     self.dms_client.update_document_status(
-                        doc_hash, DocumentStatus.COMPLETED
+                        doc_hash, doc_name, DocumentStatus.COMPLETED
                     )
+            except DocumentHashConflictException as hash_exception:
+                logger.error(f"Failed to ingest {document}: {hash_exception}")
+                raise
             except Exception as e:
                 logger.error(f"Failed to ingest {document}: {e}")
-                self._try_set_error_status(doc_hash, document)
+                self._try_set_error_status(doc_hash, doc_name, document)
                 raise
 
     # To be called when there's an exception processing
-    def _try_set_error_status(self, doc_hash: str, document: str):
+    def _try_set_error_status(self, doc_hash: str, doc_name: str, document: str):
         try:
-            self.dms_client.update_document_status(doc_hash, DocumentStatus.ERROR)
+            self.dms_client.update_document_status(
+                doc_hash, doc_name, DocumentStatus.ERROR
+            )
         except Exception:
             logger.warning(f"Could not set ERROR status for {document}")
+
+    def _extract_doc_name(self, document: str) -> str:
+        parsed = urlparse(document)
+        path = parsed.path if parsed.scheme else document
+        return os.path.basename(path)

--- a/src/ingestion_service/document_management_client.py
+++ b/src/ingestion_service/document_management_client.py
@@ -1,5 +1,6 @@
 from typing import List
 import requests
+from src.shared.exceptions import DocumentHashConflictException
 from src.shared.models import (
     GetDocumentStatusResponse,
     SetDocumentStatusRequest,
@@ -14,7 +15,7 @@ class DocumentManagementClient:
 
     def get_document_status(self, doc_hash: str) -> DocumentStatus | None:
         try:
-            response = requests.get(f"{self.base_url}/documents/{doc_hash}/status")
+            response = requests.get(f"{self.base_url}/documents/{doc_hash}/status/")
             if response.status_code == 404:
                 return None
         except Exception:
@@ -24,21 +25,25 @@ class DocumentManagementClient:
         return DocumentStatus(parsed_response.status)
 
     def update_document_status(
-        self, doc_hash: str, document_status: DocumentStatus
+        self, doc_hash: str, doc_name: str, document_status: DocumentStatus
     ) -> None:
         try:
-            request_body = SetDocumentStatusRequest(status=document_status)
+            request_body = SetDocumentStatusRequest(
+                doc_name=doc_name, status=document_status
+            )
             response = requests.put(
-                f"{self.base_url}/documents/{doc_hash}/status",
+                f"{self.base_url}/documents/{doc_hash}/status/",
                 json=request_body.model_dump(),
             )
+            if response.status_code == 409:
+                raise DocumentHashConflictException
         except Exception:
             raise
         response.raise_for_status()
 
     def get_documents(self) -> List[DMSDocument]:
         try:
-            response = requests.get(f"{self.base_url}/documents")
+            response = requests.get(f"{self.base_url}/documents/")
             if response.status_code == 204:
                 return []
         except Exception:

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -56,3 +56,9 @@ class IngestionRequestException(Exception):
     """Raised when there's an issue ingesting documents to vector store."""
 
     pass
+
+
+class DocumentHashConflictException(Exception):
+    """Raised when doc_hash already exists with a different doc_name."""
+
+    pass

--- a/src/shared/models.py
+++ b/src/shared/models.py
@@ -14,9 +14,6 @@ class GetDocumentStatusResponse(BaseModel):
     status: DocumentStatus
 
 
-class RegisterDocumentRequest(BaseModel):
-    doc_name: str = Field(..., min_length=1)
-
-
 class SetDocumentStatusRequest(BaseModel):
+    doc_name: str = Field(..., min_length=1)
     status: DocumentStatus

--- a/tests/contract/ingestion_service/test_document_management.py
+++ b/tests/contract/ingestion_service/test_document_management.py
@@ -3,6 +3,7 @@ import pytest
 from pact import Pact
 from src.ingestion_service.document_management_client import DocumentManagementClient
 from src.shared.constants import DocumentStatus
+from src.shared.exceptions import DocumentHashConflictException
 from src.shared.models import DMSDocument
 
 sample_hash = "d41d8cd98f00b204e9800998ecf8427e"
@@ -23,7 +24,7 @@ def test_get_document_status_document_returns_404(pact):
     (
         pact.upon_receiving("Get status for unknown document")
         .given(f"DMS has no knowledge of document {sample_hash}")
-        .with_request("GET", f"/documents/{sample_hash}/status")
+        .with_request("GET", f"/documents/{sample_hash}/status/")
         .will_respond_with(404)
     )
 
@@ -46,7 +47,7 @@ def test_get_document_status_document_pending(pact, status):
     (
         pact.upon_receiving(f"Get status for {status} document")
         .given(f"Document {sample_hash} is {status}")
-        .with_request("GET", f"/documents/{sample_hash}/status")
+        .with_request("GET", f"/documents/{sample_hash}/status/")
         .will_respond_with(200)
         .with_body(response)
     )
@@ -63,7 +64,7 @@ def test_get_document_status_document_pending(pact, status):
     [DocumentStatus.PENDING, DocumentStatus.COMPLETED, DocumentStatus.ERROR],
 )
 def test_update_document_status_already_existing_returns_success(pact, status):
-    request = {"status": status}
+    request = {"doc_name": sample_doc_name, "status": status}
 
     response = {
         "doc_hash": sample_hash,
@@ -74,7 +75,7 @@ def test_update_document_status_already_existing_returns_success(pact, status):
     (
         pact.upon_receiving(f"Request to update existing document status to {status}")
         .given(f"Document {sample_hash} already exists in the db")
-        .with_request("PUT", f"/documents/{sample_hash}/status")
+        .with_request("PUT", f"/documents/{sample_hash}/status/")
         .with_body(request)
         .will_respond_with(204)
         .with_body(response)
@@ -83,7 +84,9 @@ def test_update_document_status_already_existing_returns_success(pact, status):
     with pact.serve() as srv:
         dms_client = DocumentManagementClient(srv.url)
 
-        response = dms_client.update_document_status(sample_hash, status)
+        response = dms_client.update_document_status(
+            sample_hash, sample_doc_name, status
+        )
         assert response is None
 
 
@@ -92,7 +95,7 @@ def test_update_document_status_already_existing_returns_success(pact, status):
     [DocumentStatus.PENDING, DocumentStatus.COMPLETED, DocumentStatus.ERROR],
 )
 def test_update_document_status_not_existing_returns_success(pact, status):
-    request = {"status": status}
+    request = {"doc_name": sample_doc_name, "status": status}
 
     response = {
         "doc_hash": sample_hash,
@@ -103,7 +106,7 @@ def test_update_document_status_not_existing_returns_success(pact, status):
     (
         pact.upon_receiving(f"Request to update new document status to {status}")
         .given(f"Document {sample_hash} does not exist in the db")
-        .with_request("PUT", f"/documents/{sample_hash}/status")
+        .with_request("PUT", f"/documents/{sample_hash}/status/")
         .with_body(request)
         .will_respond_with(201)
         .with_body(response)
@@ -112,8 +115,35 @@ def test_update_document_status_not_existing_returns_success(pact, status):
     with pact.serve() as srv:
         dms_client = DocumentManagementClient(srv.url)
 
-        response = dms_client.update_document_status(sample_hash, status)
+        response = dms_client.update_document_status(
+            sample_hash, sample_doc_name, status
+        )
         assert response is None
+
+
+def test_update_document_status_mismatching_doc_name_returns_409(pact):
+    mismatching_doc_name = "doc_name_mismatch"
+    request = {"doc_name": mismatching_doc_name, "status": DocumentStatus.COMPLETED}
+
+    (
+        pact.upon_receiving(
+            f"Request to update document status with {mismatching_doc_name}"
+        )
+        .given(
+            f"Document {sample_hash} exists in the db with doc_name {sample_doc_name}"
+        )
+        .with_request("PUT", f"/documents/{sample_hash}/status/")
+        .with_body(request)
+        .will_respond_with(409)
+    )
+
+    with pact.serve() as srv:
+        dms_client = DocumentManagementClient(srv.url)
+
+        with pytest.raises(DocumentHashConflictException):
+            dms_client.update_document_status(
+                sample_hash, mismatching_doc_name, DocumentStatus.COMPLETED
+            )
 
 
 def test_get_ingested_documents_returns_list(pact):
@@ -134,7 +164,7 @@ def test_get_ingested_documents_returns_list(pact):
             "Request to get processed documents and DMS has processed docs"
         )
         .given("DMS has documents registered")
-        .with_request("GET", "/documents")
+        .with_request("GET", "/documents/")
         .will_respond_with(200)
         .with_body(response)
     )
@@ -150,7 +180,7 @@ def test_get_ingested_documents_returns_empty(pact):
             "Request to get processed documents and DMS has no processed docs"
         )
         .given("DMS has no documents registered")
-        .with_request("GET", "/documents")
+        .with_request("GET", "/documents/")
         .will_respond_with(204)
     )
     with pact.serve() as srv:

--- a/tests/unit/ingestion_service/test_document_ingestor.py
+++ b/tests/unit/ingestion_service/test_document_ingestor.py
@@ -1,5 +1,5 @@
 from unittest.mock import ANY, Mock, call, patch
-from pytest import fixture
+from pytest import fixture, mark
 import pytest
 from requests import HTTPError
 from src.ingestion_service.document_management_client import DocumentManagementClient
@@ -7,7 +7,7 @@ from src.ingestion_service.document_ingestor import DocumentIngestor
 from src.ingestion_service.file_loader import FileLoader
 from src.ingestion_service.vector_store_builder import VectorStoreBuilder
 from src.shared.constants import DocumentStatus
-from src.shared.exceptions import NoDocumentsException
+from src.shared.exceptions import DocumentHashConflictException, NoDocumentsException
 
 
 class TestDocumentIngestor:
@@ -66,8 +66,8 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 2
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.COMPLETED),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.COMPLETED),
             ]
         )
         mock_process_document.assert_called_once()
@@ -95,8 +95,8 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 2
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.ERROR),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.ERROR),
             ]
         )
         mock_process_document.assert_called_once()
@@ -126,8 +126,8 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 2
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.ERROR),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.ERROR),
             ]
         )
         mock_process_document.assert_called_once()
@@ -154,8 +154,8 @@ class TestDocumentIngestor:
         mock_dms_client.get_document_status.assert_called_once()
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.ERROR),  # Called by _try_set_error_status
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.ERROR),  # Called by _try_set_error_status
             ]
         )
         mock_process_document.assert_not_called()
@@ -243,8 +243,8 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 2
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.COMPLETED),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.COMPLETED),
             ]
         )
         mock_process_document.assert_called_once()
@@ -273,8 +273,8 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 2
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.COMPLETED),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.COMPLETED),
             ]
         )
         mock_process_document.assert_called_once()
@@ -305,13 +305,74 @@ class TestDocumentIngestor:
         assert mock_dms_client.update_document_status.call_count == 6
         mock_dms_client.update_document_status.assert_has_calls(
             [
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.COMPLETED),
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.ERROR),
-                call(ANY, DocumentStatus.PENDING),
-                call(ANY, DocumentStatus.COMPLETED),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.COMPLETED),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.ERROR),
+                call(ANY, ANY, DocumentStatus.PENDING),
+                call(ANY, ANY, DocumentStatus.COMPLETED),
             ]
         )
         assert mock_process_document.call_count == 3
         assert mock_vector_store_builder.add_documents_to_vector_store.call_count == 3
+
+    @patch("src.ingestion_service.document_ingestor.process_document")
+    def test_ingest_document_hash_conflict_does_not_set_error_status(
+        self,
+        mock_process_document,
+        mock_file_loader,
+        mock_vector_store_builder,
+        mock_dms_client,
+    ):
+        """When DocumentHashConflictException is raised, do not set ERROR status."""
+        doc_ingestor = DocumentIngestor(
+            mock_dms_client, mock_vector_store_builder, mock_file_loader, print
+        )
+        document = "Document"
+        mock_dms_client.update_document_status.side_effect = (
+            DocumentHashConflictException()
+        )
+
+        with pytest.raises(DocumentHashConflictException):
+            doc_ingestor.ingest_document(document)
+
+        mock_dms_client.get_document_status.assert_called_once()
+        # Only called once (PENDING) - no ERROR status should be set
+        mock_dms_client.update_document_status.assert_called_once_with(
+            ANY, ANY, DocumentStatus.PENDING
+        )
+        # Processing should not happen
+        mock_process_document.assert_not_called()
+        mock_vector_store_builder.add_documents_to_vector_store.assert_not_called()
+
+    @mark.parametrize(
+        "document_path,expected_name",
+        [
+            # Local paths
+            ("/local/path/to/report.pdf", "report.pdf"),
+            ("/home/user/documents/analysis.pdf", "analysis.pdf"),
+            ("simple.pdf", "simple.pdf"),
+            # S3 URIs
+            ("s3://bucket/folder/document.pdf", "document.pdf"),
+            ("s3://my-bucket/path/to/analysis.pdf", "analysis.pdf"),
+            # HTTPS URLs
+            ("https://bucket.s3.amazonaws.com/docs/summary.pdf", "summary.pdf"),
+            ("https://example.com/files/report.pdf", "report.pdf"),
+        ],
+    )
+    def test_extract_doc_name_from_various_paths(
+        self,
+        mock_file_loader,
+        mock_vector_store_builder,
+        mock_dms_client,
+        document_path,
+        expected_name,
+    ):
+        """Test that doc_name is correctly extracted from various path formats."""
+        doc_ingestor = DocumentIngestor(
+            mock_dms_client, mock_vector_store_builder, mock_file_loader, print
+        )
+
+        result = doc_ingestor._extract_doc_name(document_path)
+
+        assert result == expected_name


### PR DESCRIPTION
DocumentHashConflictException, add doc_name as parameter to SetDocumentStatusRequest, update and create 409 contract test. Updated unit tests. Add trailing slash to DMS routes for consistency.