### PR TITLE
Show No Documents error in frontend #74

### DIFF
--- a/docs/ADR_LOG.md
+++ b/docs/ADR_LOG.md
@@ -531,3 +531,13 @@
 **Tags**: [testing, e2e, test-strategy, playwright, fastapi, pragmatism]
 
 ---
+
+**ID**: ADR-053
+**Date**: 2026-04-10
+**Context**: The inference service returns HTTP 503 when no documents are in the vector store. The UI was swallowing this as a generic error, giving users no actionable feedback.
+**Decision**: Introduce `NoDocumentsIngestedError` as a named exception class in the UI client. The client checks for `status_code == 503` before `raise_for_status()`, extracts the detail from the response body, and raises the named exception. The Streamlit caller catches it separately and shows `st.warning`. All other errors remain on the existing `st.error` path.
+**Rationale**: Named exception keeps the error domain explicit and testable (Pact consumer test can assert on it). Pulling the message from `response.json()["detail"]` avoids hardcoding the string in the client — the single source of truth stays in the inference service. A warning (not error) is appropriate UX since it is an actionable state the user can resolve by ingesting a document.
+**Tradeoffs**: 503 is handled specially before `raise_for_status()`; any future non-ingestion 503s from the inference service would also raise `NoDocumentsIngestedError`. Accepted because the inference service currently has exactly one 503 path.
+**Tags**: [API, error-handling, UX, pact, contract-testing]
+
+---

--- a/docs/ENGINEERING_LOG.md
+++ b/docs/ENGINEERING_LOG.md
@@ -3,6 +3,16 @@
 
 ---
 
+## 2026-04-10
+
+### Surfacing no-documents 503 error end-to-end (issue #74)
+- **Goal**: Make the empty-vector-store failure path informative for users instead of showing a generic error
+- **Solution**: Three-layer change — inference service error message made explicit and user-facing; UI client adds `NoDocumentsIngestedError` named exception that intercepts the 503 before `raise_for_status()`; Streamlit caller shows `st.warning` with the server-supplied message
+- **Pattern**: Detail string lives in exactly one place (inference service); client and UI derive from it at runtime so there's no string duplication
+- **Tests**: Pact consumer test added for the 503 interaction; Pact provider state handler added to verify the exact response body under the "no documents have been ingested" state
+
+---
+
 ## 2026-04-09
 
 ### LangChain 1.x migration — broken imports, pinned deps, and torch fix

--- a/src/inference_service/main.py
+++ b/src/inference_service/main.py
@@ -41,7 +41,7 @@ def get_documents() -> List[DMSDocument]:
 def ensure_vector_store_ready():
     """Raise HTTP 503 if the vector store contains no documents."""
     if get_vectordb_collection_count() == 0:
-        raise HTTPException(503, "Vector store not ready")
+        raise HTTPException(503, "No documents have been ingested yet. Please ingest at least one document before chatting.")
 
 
 @app.get("/health")

--- a/src/ui_service/inference_service_client.py
+++ b/src/ui_service/inference_service_client.py
@@ -12,6 +12,10 @@ HEALTH_CHECK_TIMEOUT = 5
 CHAT_TIMEOUT = 30
 
 
+class NoDocumentsIngestedError(Exception):
+    """Raised when the inference service reports no documents have been ingested."""
+
+
 @dataclass
 class DocumentInfo:
     """Lightweight representation of a document entry returned by the health endpoint."""
@@ -87,6 +91,8 @@ class InferenceServiceClient:
             json={"question": question, "session_id": session_id},
             timeout=CHAT_TIMEOUT,
         )
+        if response.status_code == 503:
+            raise NoDocumentsIngestedError(response.json()["detail"])
         response.raise_for_status()
         data = response.json()
         return ChatResponse(

--- a/src/ui_service/inference_service_client.py
+++ b/src/ui_service/inference_service_client.py
@@ -92,7 +92,16 @@ class InferenceServiceClient:
             timeout=CHAT_TIMEOUT,
         )
         if response.status_code == 503:
-            raise NoDocumentsIngestedError(response.json()["detail"])
+            try:
+                detail = response.json().get("detail", "Service unavailable.")
+            except ValueError:
+                detail = "Service unavailable."
+            if (
+                "no documents" in detail.lower()
+                or "not been ingested" in detail.lower()
+            ):
+                raise NoDocumentsIngestedError(detail)
+            response.raise_for_status()
         response.raise_for_status()
         data = response.json()
         return ChatResponse(

--- a/src/ui_service/streamlit_app.py
+++ b/src/ui_service/streamlit_app.py
@@ -6,7 +6,10 @@ from typing import List
 
 import streamlit as st
 
-from src.ui_service.inference_service_client import InferenceServiceClient
+from src.ui_service.inference_service_client import (
+    InferenceServiceClient,
+    NoDocumentsIngestedError,
+)
 
 INFERENCE_SERVICE_URL = os.getenv("INFERENCE_SERVICE_URL", "http://localhost:8000")
 
@@ -58,6 +61,9 @@ def _render_domain_expert() -> None:
     with st.spinner("Thinking..."):
         try:
             response = client.ask_question(prompt, st.session_state.domain_session_id)
+        except NoDocumentsIngestedError as exc:
+            st.warning(str(exc))
+            return
         except Exception as exc:
             st.error(f"Request failed: {exc}")
             return

--- a/tests/contract/inference_service/test_ui_service.py
+++ b/tests/contract/inference_service/test_ui_service.py
@@ -44,8 +44,7 @@ def given_has_no_documents(parameters: dict[str, Any] | None = None) -> None:
 
 
 def given_no_documents_ingested(parameters: dict[str, Any] | None = None) -> None:
-    mock_vector_store_loader.get_collection_count.return_value = 0
-    mock_dms_client.get_documents.return_value = []
+    given_has_no_documents(parameters)
 
 
 @pytest.fixture(scope="session")

--- a/tests/contract/inference_service/test_ui_service.py
+++ b/tests/contract/inference_service/test_ui_service.py
@@ -43,6 +43,11 @@ def given_has_no_documents(parameters: dict[str, Any] | None = None) -> None:
     mock_dms_client.get_documents.return_value = []
 
 
+def given_no_documents_ingested(parameters: dict[str, Any] | None = None) -> None:
+    mock_vector_store_loader.get_collection_count.return_value = 0
+    mock_dms_client.get_documents.return_value = []
+
+
 @pytest.fixture(scope="session")
 def application():
     """Start up inference service for provider tests."""
@@ -77,6 +82,7 @@ class TestUiService:
     state_handlers = {
         "Inference service has documents loaded": given_has_documents_loaded,
         "Inference service has no documents": given_has_no_documents,
+        "no documents have been ingested": given_no_documents_ingested,
     }
 
     def test_provider_from_broker(self, application):

--- a/tests/contract/ui_service/test_inference_health.py
+++ b/tests/contract/ui_service/test_inference_health.py
@@ -2,7 +2,10 @@ from typing import Generator
 import pytest
 from pact import Pact
 
-from src.ui_service.inference_service_client import InferenceServiceClient
+from src.ui_service.inference_service_client import (
+    InferenceServiceClient,
+    NoDocumentsIngestedError,
+)
 
 
 @pytest.fixture
@@ -72,3 +75,27 @@ class TestInferenceHealth:
         assert result.is_healthy is True
         assert result.vector_store_count == 0
         assert result.documents == []
+
+
+class TestInferenceChatNoDocuments:
+    def test_chat_no_documents_ingested(self, pact):
+        response_body = {
+            "detail": "No documents have been ingested yet. Please ingest at least one document before chatting."
+        }
+        (
+            pact.upon_receiving("Post chat when no documents have been ingested")
+            .given("no documents have been ingested")
+            .with_request("POST", "/chat/domain-expert/")
+            .will_respond_with(503)
+            .with_body(response_body)
+        )
+
+        with pact.serve() as srv:
+            client = InferenceServiceClient(srv.url)
+            with pytest.raises(NoDocumentsIngestedError) as exc_info:
+                client.ask_question("What is RAG?")
+
+        assert str(exc_info.value) == (
+            "No documents have been ingested yet. "
+            "Please ingest at least one document before chatting."
+        )

--- a/tests/e2e/test_e2e_flow.py
+++ b/tests/e2e/test_e2e_flow.py
@@ -82,7 +82,8 @@ class TestE2EFlow:
         inference_response_string = "Defect Prevention Costs"
         chat_input = page.get_by_role("textbox")
         chat_submit_button = page.get_by_test_id("stChatInputSubmitButton")
-        alert_container = page.get_by_test_id("stAlertContentError")
+        alert_container = page.get_by_test_id("stAlertContentWarning")
+        alert_text = "No documents have been ingested yet. Please ingest at least one document before chatting."
         system_status_sidebar_button = page.get_by_text("System Status")
         chat_sidebar_button = page.get_by_text("Chat")
         vector_store_doc_count = page.get_by_test_id("documents_in_vector_store_count")
@@ -96,10 +97,7 @@ class TestE2EFlow:
         chat_input.type(inference_string)
         chat_submit_button.click()
         # Assert - Verify error message is displayed
-        expect(alert_container).to_have_text(
-            ("Request failed: 503 Server Error: Service Unavailable for url: ")
-            + ("http://inference_service:8000/chat/domain-expert/")
-        )
+        expect(alert_container).to_have_text(alert_text)
         # Act - Navigate to system status sidebar
         system_status_sidebar_button.click()
         # Assert - Verify vector store document count is 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now shows a clear warning when chatting with no ingested documents, preventing a generic error path.

* **Documentation**
  * Added ADR and engineering log entries describing the refined no-documents failure handling and single-source messaging rule.

* **Tests**
  * Added/updated contract and end-to-end tests to verify the no-documents scenario and the warning display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->