### PR TITLE
Remove deprecated DMS provider state handlers

### DIFF
--- a/tests/contract/document_management_service/test_ingestion.py
+++ b/tests/contract/document_management_service/test_ingestion.py
@@ -136,12 +136,8 @@ class TestIngestion:
             status=DocumentStatus.PENDING,
         ),
         f"DMS has no knowledge of document {sample_hash}": given_document_not_found,
-        # Old state names (for main branch pacts)
         "DMS has no documents registered": given_dms_has_no_documents,
         "DMS has documents registered": given_dms_has_two_documents,
-        # New state names (for current branch pacts)
-        "DMS has no documents": given_dms_has_no_documents,
-        "DMS has one document": given_dms_has_one_document,
         "DMS has multiple documents": given_dms_has_multiple_documents,
         f"Document {sample_hash} exists in the db with doc_name {sample_doc_name}": given_document_exists_with_name,
         f"Document {sample_hash} already exists in the db": given_document_exists,

--- a/tests/contract/document_management_service/test_ingestion.py
+++ b/tests/contract/document_management_service/test_ingestion.py
@@ -41,16 +41,6 @@ def given_dms_has_no_documents() -> None:
     return
 
 
-def given_dms_has_two_documents() -> None:
-    document_1 = DMSDocument(
-        doc_hash=sample_hash, doc_name=sample_doc_name, status=DocumentStatus.PENDING
-    )
-    document_2 = DMSDocument(
-        doc_hash="Doc Hash 2", doc_name="Doc Name 2", status=DocumentStatus.COMPLETED
-    )
-    mock_db_client.get_documents.return_value = [document_1, document_2]
-
-
 def given_dms_has_one_document() -> None:
     document = DMSDocument(
         doc_hash="Doc Hash 1", doc_name="Doc Name 1", status=DocumentStatus.PENDING
@@ -136,8 +126,8 @@ class TestIngestion:
             status=DocumentStatus.PENDING,
         ),
         f"DMS has no knowledge of document {sample_hash}": given_document_not_found,
-        "DMS has no documents registered": given_dms_has_no_documents,
-        "DMS has documents registered": given_dms_has_two_documents,
+        "DMS has no documents": given_dms_has_no_documents,
+        "DMS has one document": given_dms_has_one_document,
         "DMS has multiple documents": given_dms_has_multiple_documents,
         f"Document {sample_hash} exists in the db with doc_name {sample_doc_name}": given_document_exists_with_name,
         f"Document {sample_hash} already exists in the db": given_document_exists,

--- a/tests/contract/document_management_service/test_ingestion.py
+++ b/tests/contract/document_management_service/test_ingestion.py
@@ -41,16 +41,6 @@ def given_dms_has_no_documents() -> None:
     return
 
 
-def given_dms_has_two_documents() -> None:
-    document_1 = DMSDocument(
-        doc_hash=sample_hash, doc_name=sample_doc_name, status=DocumentStatus.PENDING
-    )
-    document_2 = DMSDocument(
-        doc_hash="Doc Hash 2", doc_name="Doc Name 2", status=DocumentStatus.COMPLETED
-    )
-    mock_db_client.get_documents.return_value = [document_1, document_2]
-
-
 def given_dms_has_one_document() -> None:
     document = DMSDocument(
         doc_hash="Doc Hash 1", doc_name="Doc Name 1", status=DocumentStatus.PENDING
@@ -136,10 +126,6 @@ class TestIngestion:
             status=DocumentStatus.PENDING,
         ),
         f"DMS has no knowledge of document {sample_hash}": given_document_not_found,
-        # Old state names (for main branch pacts)
-        "DMS has no documents registered": given_dms_has_no_documents,
-        "DMS has documents registered": given_dms_has_two_documents,
-        # New state names (for current branch pacts)
         "DMS has no documents": given_dms_has_no_documents,
         "DMS has one document": given_dms_has_one_document,
         "DMS has multiple documents": given_dms_has_multiple_documents,

--- a/tests/contract/document_management_service/test_ingestion.py
+++ b/tests/contract/document_management_service/test_ingestion.py
@@ -41,6 +41,16 @@ def given_dms_has_no_documents() -> None:
     return
 
 
+def given_dms_has_two_documents() -> None:
+    document_1 = DMSDocument(
+        doc_hash=sample_hash, doc_name=sample_doc_name, status=DocumentStatus.PENDING
+    )
+    document_2 = DMSDocument(
+        doc_hash="Doc Hash 2", doc_name="Doc Name 2", status=DocumentStatus.COMPLETED
+    )
+    mock_db_client.get_documents.return_value = [document_1, document_2]
+
+
 def given_dms_has_one_document() -> None:
     document = DMSDocument(
         doc_hash="Doc Hash 1", doc_name="Doc Name 1", status=DocumentStatus.PENDING
@@ -126,6 +136,10 @@ class TestIngestion:
             status=DocumentStatus.PENDING,
         ),
         f"DMS has no knowledge of document {sample_hash}": given_document_not_found,
+        # Old state names (for main branch pacts)
+        "DMS has no documents registered": given_dms_has_no_documents,
+        "DMS has documents registered": given_dms_has_two_documents,
+        # New state names (for current branch pacts)
         "DMS has no documents": given_dms_has_no_documents,
         "DMS has one document": given_dms_has_one_document,
         "DMS has multiple documents": given_dms_has_multiple_documents,

--- a/tests/contract/ingestion_service/test_document_management.py
+++ b/tests/contract/ingestion_service/test_document_management.py
@@ -148,8 +148,8 @@ def test_update_document_status_mismatching_doc_name_returns_409(pact):
 def test_get_ingested_documents_returns_list(pact):
     response = [
         {
-            "doc_hash": sample_hash,
-            "doc_name": sample_doc_name,
+            "doc_hash": "Doc Hash 1",
+            "doc_name": "Doc Name 1",
             "status": DocumentStatus.PENDING,
         },
         {
@@ -157,12 +157,17 @@ def test_get_ingested_documents_returns_list(pact):
             "doc_name": "Doc Name 2",
             "status": DocumentStatus.COMPLETED,
         },
+        {
+            "doc_hash": "Doc Hash 3",
+            "doc_name": "Doc Name 3",
+            "status": DocumentStatus.ERROR,
+        },
     ]
     (
         pact.upon_receiving(
-            "Request to get processed documents and DMS has processed docs"
+            "Request to get processed documents and DMS has multiple documents"
         )
-        .given("DMS has documents registered")
+        .given("DMS has multiple documents")
         .with_request("GET", "/documents/")
         .will_respond_with(200)
         .with_body(response)
@@ -176,9 +181,9 @@ def test_get_ingested_documents_returns_list(pact):
 def test_get_ingested_documents_returns_empty(pact):
     (
         pact.upon_receiving(
-            "Request to get processed documents and DMS has no processed docs"
+            "Request to get processed documents and DMS has no documents"
         )
-        .given("DMS has no documents registered")
+        .given("DMS has no documents")
         .with_request("GET", "/documents/")
         .will_respond_with(204)
     )


### PR DESCRIPTION
Removes the old state names ("DMS has no documents registered", "DMS has documents registered") and the unused given_dms_has_two_documents helper now that PR #56 is merged and new pact state names are canonical. Also removes the transitional comments distinguishing old/new names.

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated contract tests for document ingestion: consolidated provider state names, removed a redundant two-document state, and refined test fixtures to return clearer example document entries (including an added third entry and an error-status case). These changes simplify test setup and improve clarity of contract examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->